### PR TITLE
Resolve choice 955 for every Cave Before Time task

### DIFF
--- a/src/engine.ts
+++ b/src/engine.ts
@@ -11,6 +11,7 @@ import {
   bjornifyFamiliar,
   enthroneFamiliar,
   equippedAmount,
+  myAscensions,
   setAutoAttack,
 } from "kolmafia";
 import {
@@ -26,7 +27,7 @@ import {
 
 import { garboAverageValue, garboValue } from "./garboValue";
 import { bestJuneCleaverOption, shouldSkip } from "./juneCleaver";
-import { printd, sober } from "./lib";
+import { args, printd, sober } from "./lib";
 import type Macro from "./macro";
 
 export type ChronerTask = Task & {
@@ -83,6 +84,15 @@ export class ChronerEngine extends Engine<never, ChronerTask> {
   }
 
   setChoices(task: ChronerTask, manager: PropertiesManager): void {
+    // Withheld until Caveman Dan is settled: those tasks resolve choice 955 via runChoice.
+    if (
+      args.mode !== "rock" ||
+      get("_questCaveDan", 0) > 4 ||
+      get("lastCaveDanDefeat", 0) >= myAscensions()
+    ) {
+      manager.setChoice(955, 2);
+    }
+
     super.setChoices(task, manager);
     if (equippedAmount($item`June cleaver`) > 0) {
       this.propertyManager.setChoices(


### PR DESCRIPTION
Choice 955 (`Time Cave.  Period.`) has no KoLmafia default, so any task
adventuring in The Cave Before Time aborts the whole run with "Manual control
requested for choice #955" unless it's already been set. Only `Time Capsule`
declared `choices: { 955: 2 }`; `Chroner`, `Spikolodon Spikes`, `Void Monster`,
`Bowling Ball Run`, `Asdon Bumper`, `Asdon Missile`, and `Spit Jurassic Acid`
all depend on ambient state instead. Intermittent because `PropertiesManager`
doesn't unwind per task — once `Time Capsule` ran, `choiceAdventure955` stayed
`2` for the rest of the session. Observed live on `Spit Jurassic Acid`.

Sets the baseline once in `ChronerEngine.setChoices`, next to the existing
June Cleaver override, instead of repeating `choices: { 955: 2 }` on every
task — `super.setChoices` still runs after, so a task's own value wins.

Gated on rock mode's Caveman Dan quest being settled: those tasks drive
choice 955 imperatively via `runChoice`, and an automated resolution would
intercept it before `runChoice` sees it, looping the tasks indefinitely
(choice #954 has no automation support either, so option 3 isn't a fix).
Reuses `Time Capsule`'s existing readiness check for the gate.

---
Assisted by Claude Code — reviewed by @eegeeZA; verified via `yarn lint` and `yarn build`.
